### PR TITLE
Remove leading whitespace 

### DIFF
--- a/Core/Worker/Mediator.php
+++ b/Core/Worker/Mediator.php
@@ -1,4 +1,4 @@
- <?php
+<?php
 /**
  * Create and run worker processes.
  * Use message queues and shared memory to coordinate worker processes and return work product to the daemon.


### PR DESCRIPTION
`Core/Worker/Mediator.php` had some leading whitespace before the `<?php` tag which was making some daemons crash after an auto restart.
