### PR TITLE
Fixing incorrect extension check condition (were "!!" instead of "!")

### DIFF
--- a/Examples/LongPoll/API.php
+++ b/Examples/LongPoll/API.php
@@ -70,7 +70,7 @@ class API implements \Core_IWorker
     public function check_environment()
     {
         $errors = array();
-        if (!!function_exists('curl_init'))
+        if (!function_exists('curl_init'))
             $errors[] = 'PHP Curl Extension Required: Recompile PHP using the --with-curl option.';
 
         // Currently this class just simulates an API call by generating random results and sleeping a random time.


### PR DESCRIPTION
I was trying to run LongPoll example and was having an error about missing Curl extension, but I was sure I had it installed.

Problem was hidden beneath duplicate ! sign in comparison operator.
