### PR TITLE
Add OS X support to clean_ipc.php

### DIFF
--- a/scripts/clean_ipc.php
+++ b/scripts/clean_ipc.php
@@ -42,7 +42,7 @@ exec('ipcs', $ipcs);
 foreach($ipcs as $row) {
 
     if (!isset($opt['m'])) {
-        if (strpos($row, 'Shared Memory Segments') > 0) {
+        if (strpos($row, 'Shared Memory') !== FALSE) {
             echo PHP_EOL, "Cleaning Shared Memory Segments...";
             $flag = '-m';
             continue;
@@ -50,7 +50,7 @@ foreach($ipcs as $row) {
     }
 
     if (!isset($opt['q'])) {
-        if (strpos($row, 'Message Queues') > 0) {
+        if (strpos($row, 'Message Queues') !== FALSE) {
             echo PHP_EOL, "Cleaning Message Queues...";
             $flag = '-q';
             continue;
@@ -58,7 +58,7 @@ foreach($ipcs as $row) {
     }
 
     if (!isset($opt['s'])) {
-        if (strpos($row, 'Semaphore Arrays') > 0) {
+        if (strpos($row, 'Semaphore') !== FALSE) {
             echo PHP_EOL, "Cleaning Semaphore Arrays...";
             $flag = '-s';
             continue;


### PR DESCRIPTION
Adds support for OS X format of `ipcs`. The original format should be matched fine.

``` sh
➜  PHP-Daemon git:(master) ✗ ipcs
IPC status from <running system> as of Fri Jan 17 20:12:57 CET 2014
T     ID     KEY        MODE       OWNER    GROUP
Message Queues:
q  65536 0x41046f6a --rw-rw-rw-  mikulas    staff

T     ID     KEY        MODE       OWNER    GROUP
Shared Memory:
m 458752 0x00000000 --rw-------  mikulas    staff
m  65538 0x4d04006c --rw-rw----     root    staff

T     ID     KEY        MODE       OWNER    GROUP
Semaphores:
s  65536 0x0b048802 --ra-ra-ra-  mikulas    staff
```
