### PR TITLE
Added fix for fatal error during worker cleanup that fixes issue #41

### DIFF
--- a/Core/Worker/Mediator.php
+++ b/Core/Worker/Mediator.php
@@ -721,7 +721,9 @@ abstract class Core_Worker_Mediator implements Core_ITask
 
                         $this->log("Enforcing Timeout on Call $call_id in pid " . $call->pid);
 
-                        $this->process($call->pid)->kill();
+                        if($this->process($call->pid) instanceof Core_Lib_Process) {
+                          $this->process($call->pid)->kill();
+                        }
                         $call->timeout();
                         unset($this->running_calls[$call_id]);
 
@@ -997,6 +999,14 @@ abstract class Core_Worker_Mediator implements Core_ITask
         return 0;
     }
 
+    /**
+     * Retrieves the number of worker processes that are currently running
+     *
+     * @return number
+     */
+    public function running_count() {
+      return count($this->running_calls);
+    }
 
     /**
      * Dump runtime stats in tabular fashion to the log.


### PR DESCRIPTION
Also added running_count method to Mediator.  This adds additional possibilities for determining when to give a worker more work.
