### PR TITLE
plugin File fix

### DIFF
--- a/Core/Lock/File.php
+++ b/Core/Lock/File.php
@@ -40,7 +40,7 @@ class Core_Lock_File extends Core_Lock_Lock implements Core_IPlugin
     public function teardown()
     {
         // If the lockfile was set by this process, remove it. If filename is empty, this is being called before setup()
-        if (!empty($this->filename) && $this->pid == @file_get_contents($this->filename))
+        if (!empty($this->filename) && getmypid() == @file_get_contents($this->filename))
             @unlink($this->filename);
     }
 


### PR DESCRIPTION
$this->pid get pid before fork so it contain parent pid
because of this pid file deleted prematurely on task teardown

changed to getmypid()