### PR TITLE
Fixed broken share memory lock

### DIFF
--- a/Core/Lock/Shm.php
+++ b/Core/Lock/Shm.php
@@ -52,7 +52,9 @@ class Core_Lock_Shm extends Core_Lock_Lock implements Core_IPlugin
 	
 	protected function get()
 	{
-		$lock = shm_get_var($this->shm, self::ADDRESS);
+		$lock = array();
+        if (shm_has_var($this->shm, self::ADDRESS))
+            $lock = shm_get_var($this->shm, self::ADDRESS);
 
 		// Ensure we're not seeing our own lock
 		if ($lock['pid'] == $this->pid)

--- a/Core/Lock/Shm.php
+++ b/Core/Lock/Shm.php
@@ -45,7 +45,7 @@ class Core_Lock_Shm extends Core_Lock_Lock implements Core_IPlugin
 	{
 		$lock = $this->check();
 		if ($lock)
-			throw new Exception('Core_Lock_Shm::set Failed. Existing Lock Detected from PID ' . $lock);
+			throw new Exception('Core_Lock_Shm::set Failed. Existing Lock Detected from PID ' . $lock['pid']);
 
 		shm_put_var($this->shm, self::ADDRESS, array('pid' => $this->pid, 'time' => time()));
 	}

--- a/Core/Lock/Shm.php
+++ b/Core/Lock/Shm.php
@@ -13,8 +13,9 @@ class Core_Lock_Shm extends Core_Lock_Lock implements Core_IPlugin
      */
 	private $shm = false;
 
-	public function __construct()
-	{
+    public function __construct(Core_Daemon $daemon, Array $args = array())
+    {
+        parent::__construct($daemon, $args);
 		$this->pid = getmypid();
 	}
 	

--- a/Core/Lock/Shm.php
+++ b/Core/Lock/Shm.php
@@ -27,9 +27,16 @@ class Core_Lock_Shm extends Core_Lock_Lock implements Core_IPlugin
 	
 	public function teardown()
 	{
+        // Check shm validity before shm_get_var, return directly if NULL or FALSE
+        // This may happen when check_environment fail.
+        if ($this->shm) {
+            $lock = shm_get_var($this->shm, self::ADDRESS);
+        } else {
+            return;
+        }
+
 		// If this PID set this lock, release it
-		$lock = shm_get_var($this->shm, self::ADDRESS);
-		if ($lock == $this->pid) {
+		if ($lock['pid'] == $this->pid) {
 			shm_remove($this->shm);
             shm_detach($this->shm);
         }

--- a/Core/Lock/Shm.php
+++ b/Core/Lock/Shm.php
@@ -55,6 +55,8 @@ class Core_Lock_Shm extends Core_Lock_Lock implements Core_IPlugin
 		$lock = array();
         if (shm_has_var($this->shm, self::ADDRESS))
             $lock = shm_get_var($this->shm, self::ADDRESS);
+        else
+            return false;
 
 		// Ensure we're not seeing our own lock
 		if ($lock['pid'] == $this->pid)


### PR DESCRIPTION
# Description
Share memory lock plugin was broken. To reproduce, just change the ```Lock_File``` in Example/LongPoll to ```Lock_Shm```. You will be able to run more than one instance.

# Solution
* Fixed by using correct constructor, and call parent::__construct()

# Addtions
* Fixed exception message, ```$lock``` is an array which cannot be print directly, use $lock['pid'] instead.
* Lock retrieving optimization. 

This pull request fixed #65.