### PR TITLE
Error blocking via file

### DIFF
--- a/Core/Lock/File.php
+++ b/Core/Lock/File.php
@@ -40,7 +40,7 @@ class Core_Lock_File extends Core_Lock_Lock implements Core_IPlugin
     public function teardown()
     {
         // If the lockfile was set by this process, remove it. If filename is empty, this is being called before setup()
-        if (!empty($this->filename) && getmypid() == @file_get_contents($this->filename))
+        if (!empty($this->filename) && file_exists($this->filename) && getmypid() == @file_get_contents($this->filename))
             @unlink($this->filename);
     }
 


### PR DESCRIPTION
We got following error:
exception 'ErrorException' with message 'file_get_contents (/tmp/sms_sender_worker.daemon_lock): failed to open stream: No such file or directory' in /home/www/libs/daemon/php_daemon/2.0/Core/Lock/File.php: 42

This was because there was no /tmp/sms_sender_worker.daemon_lock file in the file system.

The problem is as follows:
With frequent attempts to start the process, at a time when the other process is running, we can get to the time period when the function "set" detects the lock file, and when you call the function "teradown" lock file will have been deleted by another process.