### PR TITLE
Template file path error

### DIFF
--- a/Core/Daemon.php
+++ b/Core/Daemon.php
@@ -1180,7 +1180,7 @@ abstract class Core_Daemon
      */
     protected function create_init_script($template_name, $install = false)
     {
-        $template = dirname($this->get('filename')) . '/Core/Templates/' . $template_name;
+	    $template = dirname(__FILE__) . '/Templates/' . $template_name;
 
         if (!file_exists($template))
             $this->show_help("Invalid Template Name '{$template_name}'");


### PR DESCRIPTION
File path is based on the current class, not the caller, especially if you are running via composer it breaks as the template directory is under ./vendor/.....